### PR TITLE
Set scheduel time to 12:30 UTC

### DIFF
--- a/.github/workflows/update-current-image.yml
+++ b/.github/workflows/update-current-image.yml
@@ -2,7 +2,7 @@ name: Update Image
 
 on:
   schedule:
-  - cron:  '0 0 * * *'
+    - cron: '30 0 * * *'
 
 env:
   IMAGE_NAME: node-minimal


### PR DESCRIPTION
From the GitHub actions docs:

"The schedule event can be delayed during periods of high loads of GitHub Actions workflow runs. High load times include the start of every hour. If the load is sufficiently high enough, some queued jobs may be dropped. To decrease the chance of delay, schedule your workflow to run at a different time of the hour."

See: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule