### PR TITLE
Add ability to skip versions

### DIFF
--- a/.github/workflows/update-current-image.yml
+++ b/.github/workflows/update-current-image.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Get NODE_VERSION
         id: get_version
-        run: echo "NODE_VERSION=$(./check-missing-versions.sh -l 4 | tail -1)" >> $GITHUB_OUTPUT
+        run: echo "NODE_VERSION=$(./check-missing-versions.sh | tail -1)" >> $GITHUB_OUTPUT
 
       - name: Show NODE_VERSION
         run: echo ${{ steps.get_version.outputs.NODE_VERSION }}


### PR DESCRIPTION
Skip the following version buils  which are broken:

- 23.6.0
- 23.5.0
- 23.4.0
- 23.3.0
- 22.13.1
- 22.13.0

Also: Use default limit of 10
