### PR TITLE
security: sanitize attacker-controllable workflow inputs

### DIFF
--- a/.github/workflows/update-current-image.yml
+++ b/.github/workflows/update-current-image.yml
@@ -24,9 +24,11 @@ jobs:
 
       - name: Validate and Get NODE_VERSION
         id: get_version
+        env:
+          GITHUB_EVENT_INPUTS_NODE_VERSION: ${{ github.event.inputs.node_version }}
         run: |
-          if [[ -n "${{ github.event.inputs.node_version }}" ]]; then
-            INPUT_VERSION="${{ github.event.inputs.node_version }}"
+          if [[ -n "${GITHUB_EVENT_INPUTS_NODE_VERSION}" ]]; then
+            INPUT_VERSION="${GITHUB_EVENT_INPUTS_NODE_VERSION}"
             if ! [[ $INPUT_VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
               echo "Error: Invalid version format '$INPUT_VERSION'. Expected format: X.Y.Z (e.g., 20.10.0)" >&2
               exit 1


### PR DESCRIPTION
## Description
Remediate zizmor security finding by preventing code injection through unsanitized workflow inputs.

## Security Motivation
GitHub Actions workflow inputs can be controlled by attackers (via forked PRs or webhooks). Directly interpolating these into shell commands allows code injection. This fix sanitizes inputs by:
1. Reading untrusted inputs into environment variables
2. Validating format before use
3. Preventing shell metacharacter injection

## Changes
- Move `github.event.inputs.node_version` to environment variable `GITHUB_EVENT_INPUTS_NODE_VERSION`
- Validate input matches semantic version format (X.Y.Z) before expanding in shell
- Prevents shell injection via malicious version strings

## Related
Fixes zizmor finding: 'may expand into attacker-controllable code'