### PR TITLE
security: resolve zizmor findings in CI workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
     commit-message:
       prefix: "ci"
       include: "scope"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "pre-commit"
     directory: "/"
     schedule:
@@ -24,4 +26,6 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    cooldown:
+      default-days: 7
 

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -10,6 +10,9 @@ on:
 env:
   IMAGE_NAME: node-minimal
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:
@@ -76,4 +79,4 @@ jobs:
           tags: ${{ env.IMAGE_NAME }}-${{ env.LATEST_VERSION }}
 
       - name: Test Image
-        run: docker run --rm ${{ env.IMAGE_NAME }}-${{ env.LATEST_VERSION }} -e "console.log('Hello from Node.js ' + process.version)"
+        run: docker run --rm "${IMAGE_NAME}-${LATEST_VERSION}" -e "console.log('Hello from Node.js ' + process.version)"

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -3,6 +3,9 @@ name: Linting
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   shfmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-current-image.yml
+++ b/.github/workflows/update-current-image.yml
@@ -13,6 +13,9 @@ on:
 env:
   IMAGE_NAME: node-minimal
 
+permissions:
+  contents: read
+
 jobs:
   check_version:
     runs-on: ubuntu-latest
@@ -130,7 +133,7 @@ jobs:
           tags: ${{ env.IMAGE_NAME }}-${{ needs.check_version.outputs.NODE_VERSION }}
 
       - name: Test Image
-        run: docker run --rm ${{ env.IMAGE_NAME }}-${{ needs.check_version.outputs.NODE_VERSION }} -e "console.log('Hello from Node.js ' + process.version)"
+        run: docker run --rm "${IMAGE_NAME}-${NODE_VERSION}" -e "console.log('Hello from Node.js ' + process.version)"
 
       - name: Docker meta
         id: meta


### PR DESCRIPTION
Resolves all findings reported by `zizmor .github/`:

- **dependabot-cooldown**: Added `cooldown: default-days: 7` to both `github-actions` and `pre-commit` ecosystems in `dependabot.yml`
- **excessive-permissions**: Added `permissions: contents: read` at the workflow level for all three workflow files
- **template-injection**: Replaced `${{ env.* }}` / `${{ needs.*.outputs.* }}` inline expansions in `run` blocks with shell variables (`${IMAGE_NAME}`, `${LATEST_VERSION}`, `${NODE_VERSION}`) in `dockerimage.yml` and `update-current-image.yml`