### PR TITLE
ci: add concurrency controls to all workflows

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -7,6 +7,10 @@ on:
       - "build.sh"
       - ".github/workflows/dockerimage.yml"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   IMAGE_NAME: node-minimal
 

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -3,6 +3,10 @@ name: Linting
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/update-current-image.yml
+++ b/.github/workflows/update-current-image.yml
@@ -10,6 +10,10 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 env:
   IMAGE_NAME: node-minimal
 


### PR DESCRIPTION
Prevents duplicate runs from wasting CI minutes.

- PR workflows (`dockerimage.yml`, `linting.yml`): cancel in-progress runs when a new push arrives on the same ref.
- Publish workflow (`update-current-image.yml`): serialize runs without cancelling, to prevent concurrent registry pushes from overwriting each other.