### PR TITLE
ci: add Docker buildx GHA layer cache to build workflows

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -81,6 +81,8 @@ jobs:
           platforms: linux/${{ matrix.platform }}
           load: true
           tags: ${{ env.IMAGE_NAME }}-${{ env.LATEST_VERSION }}
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
 
       - name: Test Image
         run: docker run --rm "${IMAGE_NAME}-${LATEST_VERSION}" -e "console.log('Hello from Node.js ' + process.version)"

--- a/.github/workflows/update-current-image.yml
+++ b/.github/workflows/update-current-image.yml
@@ -137,6 +137,8 @@ jobs:
           platforms: linux/${{ matrix.platform }}
           load: true
           tags: ${{ env.IMAGE_NAME }}-${{ env.NODE_VERSION }}
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
 
       - name: Test Image
         run: docker run --rm "${IMAGE_NAME}-${NODE_VERSION}" -e "console.log('Hello from Node.js ' + process.version)"
@@ -152,6 +154,7 @@ jobs:
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:build-${{ github.run_id }}-${{ matrix.platform }}
             ${{ env.GHCR_IMAGE }}:build-${{ github.run_id }}-${{ matrix.platform }}
+          cache-from: type=gha,scope=${{ matrix.platform }}
 
   merge:
     needs: [check_version, build]


### PR DESCRIPTION
Adds `cache-from: type=gha` / `cache-to: type=gha,mode=max` (scoped per platform) to all `docker/build-push-action` calls in both build workflows.

In `update-current-image.yml`, the push step now reuses layers warmed by the preceding test-image step. For the current `FROM scratch` Dockerfile this saves minimal time, but it correctly establishes the caching pattern for future Dockerfile changes.

**Note:** this PR is stacked on top of #288 (`ci/multi-arch-manifest`). Merge that one first, then rebase this branch onto `main` before merging.