### PR TITLE
ci: remove QEMU setup from build workflows

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -64,9 +64,6 @@ jobs:
           ccache -s
           cp node-v$LATEST_VERSION/out/Release/node node
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 

--- a/.github/workflows/update-current-image.yml
+++ b/.github/workflows/update-current-image.yml
@@ -103,9 +103,6 @@ jobs:
           ccache -s
           cp node-v$NODE_VERSION/out/Release/node node
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 


### PR DESCRIPTION
Both build workflows use native runners for each platform:
- `ubuntu-24.04` builds `linux/amd64`
- `ubuntu-24.04-arm` builds `linux/arm64`

QEMU emulation is therefore unused. Removing `docker/setup-qemu-action` from both `dockerimage.yml` and `update-current-image.yml` saves ~5–10 s per matrix job and removes an unnecessary action dependency.