### PR TITLE
ci: replace Dockerized shfmt with direct binary install

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -15,9 +15,17 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Install shfmt
+        env:
+          SHFMT_VERSION: "3.13.1"
+        run: |
+          curl -fsSL "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64" \
+            -o /usr/local/bin/shfmt
+          chmod +x /usr/local/bin/shfmt
+
       - name: shfmt
         run: |
-          docker run --rm -v "$(pwd)":/sh -w /sh mvdan/shfmt:v3 -sr -i 2 -l -w -ci .
+          shfmt -sr -i 2 -l -w -ci .
           git diff --color --exit-code
 
   shellcheck:


### PR DESCRIPTION
The `mvdan/shfmt:v3` Docker image in the `shfmt` job is not version-pinned and triggers a `docker pull` on every PR run.

Replace it with a direct binary download from GitHub releases, pinned to `v3.13.1` — matching the version already specified in `.pre-commit-config.yaml`. The shfmt flags and `git diff` check are unchanged.