### PR TITLE
ci: replace CR_PAT with GITHUB_TOKEN for GHCR auth

### DIFF
--- a/.github/workflows/update-current-image.yml
+++ b/.github/workflows/update-current-image.yml
@@ -123,7 +123,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build test image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
@@ -174,7 +174,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set major version
         run: echo "MAJOR_VERSION=$(echo "$NODE_VERSION" | cut -d'.' -f 1)" >> $GITHUB_ENV

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,4 +142,4 @@ Required for publishing (GitHub Actions secrets):
 
 - `DOCKERHUB_USERNAME` - Docker Hub username
 - `DOCKERHUB_TOKEN` - Docker Hub authentication token
-- `CR_PAT` - GitHub Container Registry personal access token
+- `GITHUB_TOKEN` - Automatically provided by GitHub Actions (no manual setup required)


### PR DESCRIPTION
Replace the manually managed `CR_PAT` secret with the automatically provided `GITHUB_TOKEN` for authenticating to GitHub Container Registry.

The workflow already declares `permissions: packages: write`, so no additional configuration is needed. The `CR_PAT` repository secret can now be deleted.