### PR TITLE
ci(dependabot): switch schedule from weekly to daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "daily"
       time: "09:30"
       timezone: "America/Toronto"
     pull-request-branch-name:
@@ -17,8 +16,7 @@ updates:
   - package-ecosystem: "pre-commit"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "daily"
       time: "09:45"
       timezone: "America/Toronto"
     pull-request-branch-name:


### PR DESCRIPTION
## Why

Dependabot's `weekly` schedule with a specific `day: "monday"` can be unreliable — GitHub does not guarantee exact execution times, and if the Monday window is missed, Dependabot may skip the week entirely.

## What changed

- Switched both `github-actions` and `pre-commit` ecosystems from `interval: "weekly"` + `day: "monday"` to `interval: "daily"`
- Removed the `day` field (not applicable to daily schedules)
- No other changes — time, timezone, cooldown, and commit message settings remain the same

## Why this is safe

The existing `cooldown: default-days: 7` on both entries ensures that once Dependabot opens a PR for a given dependency, it won't open another for that same dependency for 7 days. This means daily checks with weekly-level PR cadence — reliable weekday coverage without PR spam.