### PR TITLE
docs: sync AGENTS.md and SETUP.md with current project state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,9 @@ This repository builds minimal Node.js Docker images. To build and test locally:
 # Build Node.js binary for a specific version
 ./build.sh -n 20.10.0
 
+# Copy the compiled binary into the build context (expected by the Dockerfile)
+cp node-v20.10.0/out/Release/node node
+
 # Test the generated binary
 docker build -t node-minimal .
 docker run --rm node-minimal -e "console.log('Hello from Node.js ' + process.version)"
@@ -37,17 +40,17 @@ ENTRYPOINT ["/bin/node"]
 
 ### dockerimage.yml
 
-- Builds Docker images on PR changes to Dockerfile/build.sh
+- Builds Docker images on PR changes to `Dockerfile`, `build.sh`, or the workflow file itself
 - Tests on both linux/amd64 and linux/arm64 platforms
 - Uses ccache for faster compilation
 - Automatically detects latest Node.js version
 
 ### update-current-image.yml
 
-- Runs daily on schedule (cron: `30 0 * * *`)
-- Checks for new Node.js releases
+- Runs daily on schedule (cron: `30 0 * * *`), or manually via `workflow_dispatch` with an optional `node_version` input
+- Checks for new Node.js releases (via `check-missing-versions.sh`) unless a specific version is provided
 - Builds and publishes to Docker Hub and GitHub Container Registry
-- Tags with version, major version, and "current"
+- Tags with exact version, major version, `current`, and `latest`
 
 ### linting.yml
 
@@ -83,11 +86,15 @@ Checks for new Node.js versions to build:
 ## Code Quality
 
 - **Workflow Security:** All workflows under `.github/` must pass a [zizmor](https://docs.zizmor.sh/) audit (`zizmor .github/workflows/`) with no unsuppressed findings before merging
-- **Linting & Formatting:** Enforced via Docker-based pre-commit hooks
-- **Pre-commit hooks:** `.pre-commit-config.yaml` enforces checks locally before commit using Docker
-  - shellcheck on all `.sh` and `.bats` files (shell script linting)
-  - shfmt on all `.sh` and `.bats` files (auto-formatting with `-sr -i 2 -w -ci` flags)
-  - markdownlint-cli2 on all `.md` files (markdown linting with `.markdownlint.yaml` config)
+- **Linting & Formatting:** Enforced via `linting.yml` in CI (shfmt, shellcheck, markdownlint-cli2) and locally via pre-commit hooks
+- **Pre-commit hooks:** `.pre-commit-config.yaml` enforces the following checks locally before commit (some run via Docker, others via native binaries):
+  - `actionlint` - lints GitHub Actions workflow files
+  - `gitleaks` - scans for leaked secrets
+  - `markdownlint-cli2-docker` on all `.md` files (markdown linting with `.markdownlint.yaml` config)
+  - Standard `pre-commit-hooks`: trailing-whitespace, end-of-file-fixer, check-yaml, check-merge-conflict, check-added-large-files, mixed-line-ending
+  - `shfmt-docker` on all `.sh` and `.bats` files (auto-formatting with `-sr -i 2 -w -ci` flags)
+  - `shellcheck` on all `.sh` and `.bats` files (shell script linting)
+  - `zizmor` - GitHub Actions workflow security audit
   - See [SETUP.md](./SETUP.md) for detailed installation instructions
   - Quick start: `pre-commit install` then hooks run automatically on commit (requires Docker)
 - **Branch Protection:** main branch requires passing checks and code owner review

--- a/SETUP.md
+++ b/SETUP.md
@@ -4,13 +4,17 @@ This guide explains how to set up the pre-commit hooks for this repository on ma
 
 ## Overview
 
-Pre-commit hooks automatically validate your code before each commit, catching issues early and ensuring consistent code quality. This repository uses Docker-based pre-commit hooks to enforce:
+Pre-commit hooks automatically validate your code before each commit, catching issues early and ensuring consistent code quality. This repository configures the following hooks (some run via Docker, others via native binaries installed by the `pre-commit` framework):
 
+- **actionlint** - Lints GitHub Actions workflow files
+- **gitleaks** - Scans for leaked secrets
+- **markdownlint-cli2** (Docker) - Enforces markdown style guidelines
+- **pre-commit-hooks** - Standard checks: trailing-whitespace, end-of-file-fixer, check-yaml, check-merge-conflict, check-added-large-files, mixed-line-ending
+- **shfmt** (Docker) - Auto-formats shell scripts consistently
 - **shellcheck** - Validates shell script syntax and best practices
-- **shfmt** - Auto-formats shell scripts consistently
-- **markdownlint-cli2** - Enforces markdown style guidelines
+- **zizmor** - Audits GitHub Actions workflows for security issues
 
-These same checks also run in GitHub Actions (checkshell.yml workflow), so using pre-commit hooks locally saves time by catching issues before pushing.
+The shfmt and shellcheck checks also run in GitHub Actions (`linting.yml` workflow), so using pre-commit hooks locally saves time by catching issues before pushing.
 
 ## Prerequisites
 
@@ -74,12 +78,21 @@ pre-commit run --all-files
 You should see output like:
 
 ```bash
-shellcheck...Passed
-shfmt........Passed
-markdownlint-cli2...Passed
+Lint GitHub Actions workflow files.......................................Passed
+Detect hardcoded secrets.................................................Passed
+markdownlint-cli2-docker..................................................Passed
+trim trailing whitespace.................................................Passed
+fix end of files..........................................................Passed
+check yaml................................................................Passed
+check for merge conflicts.................................................Passed
+check for added large files...............................................Passed
+mixed line ending.........................................................Passed
+shfmt......................................................................Passed
+ShellCheck..................................................................Passed
+zizmor.....................................................................Passed
 ```
 
-All three should pass without errors. Docker will automatically pull the required container images on first run.
+All hooks should pass without errors. Docker will automatically pull the required container images on first run.
 
 ## Usage
 
@@ -133,7 +146,26 @@ git commit --no-verify
 
 ## Hook Configuration
 
-Hooks are defined in `.pre-commit-config.yaml` and run inside Docker containers. Here's what each hook does:
+Hooks are defined in `.pre-commit-config.yaml`. Here's what each hook does:
+
+### actionlint
+
+- **Purpose**: Lints GitHub Actions workflow YAML for syntax and logic errors
+- **Files checked**: `.github/workflows/*.yml`
+
+### gitleaks
+
+- **Purpose**: Scans staged changes for hardcoded secrets and credentials
+
+### pre-commit-hooks
+
+- **Purpose**: General-purpose file hygiene checks
+- **Includes**: trailing-whitespace, end-of-file-fixer, check-yaml, check-merge-conflict, check-added-large-files, mixed-line-ending
+
+### zizmor
+
+- **Purpose**: Audits GitHub Actions workflows for security issues (e.g. script injection, excessive permissions)
+- **Files checked**: `.github/workflows/*.yml`
 
 ### shellcheck
 
@@ -160,7 +192,7 @@ Detects:
   - `-ci`: Indent switch cases
 - **Docker image**: Runs in `mvdan/sh` container
 
-Matches the formatting used in CI (GitHub Actions checkshell.yml).
+Matches the formatting used in CI (GitHub Actions `linting.yml`).
 
 ### markdownlint-cli2
 
@@ -241,16 +273,19 @@ pre-commit run --all-files
 
 ### Slow first run of hooks
 
-Docker container images are large. The first run will pull required images (shellcheck, shfmt, markdownlint-cli2), which may take a few minutes.
+Docker container images are large. The first run will pull the required images (shfmt, markdownlint-cli2) and build the other hook environments (actionlint, gitleaks, shellcheck, zizmor), which may take a few minutes.
 
 **Solution**: Wait for initial pull to complete. Subsequent runs will be faster as images are cached locally.
 
 ## CI/CD Integration
 
-These same checks run in the GitHub Actions CI pipeline (`.github/workflows/checkshell.yml`):
+The shfmt, shellcheck, and markdownlint checks run in the GitHub Actions CI pipeline (`.github/workflows/linting.yml`):
 
 - **shfmt** job: Validates formatting matches the configured rules
 - **shellcheck** job: Validates shell scripts
+- **markdownlint** job: Validates Markdown files
+
+zizmor also runs as a required check against `.github/workflows/` (see [AGENTS.md](./AGENTS.md#code-quality)).
 
 Using pre-commit hooks locally ensures your changes pass CI checks before pushing.
 


### PR DESCRIPTION
## Summary
Reviewed AGENTS.md, README.md, and SETUP.md against the current state of the repo (workflows, pre-commit config, Dockerfile) and fixed the drift found in AGENTS.md and SETUP.md. README.md was already accurate and needed no changes.

## AGENTS.md
- Quick Start was missing the `cp node-v*/out/Release/node node` step that the Dockerfile actually requires (`COPY --link node /bin/`) before `docker build` will succeed.
- Pre-commit hooks list only mentioned shellcheck/shfmt/markdownlint-cli2, but `.pre-commit-config.yaml` also runs actionlint, gitleaks, zizmor, and the standard pre-commit-hooks (trailing-whitespace, end-of-file-fixer, check-yaml, check-merge-conflict, check-added-large-files, mixed-line-ending). Also clarified that only some hooks run via Docker.
- `update-current-image.yml` also tags `latest` (not just version/major/current) and supports manual `workflow_dispatch` with a `node_version` input.
- Clarified `dockerimage.yml` PR trigger paths to include the workflow file itself.

## SETUP.md
- Fixed a stale reference to a `checkshell.yml` workflow; the actual workflow is `linting.yml`.
- Documented all hooks actually configured in `.pre-commit-config.yaml` (actionlint, gitleaks, zizmor, pre-commit-hooks) instead of only shellcheck/shfmt/markdownlint-cli2.
- Clarified which hooks run via Docker vs native binaries.
- Updated the sample `pre-commit run --all-files` output and the CI/CD Integration section to match the current hook set and workflow.
